### PR TITLE
Можно избавиться от дублирования кода

### DIFF
--- a/doubly_linked.py
+++ b/doubly_linked.py
@@ -43,8 +43,26 @@ class Doubly_Linked():
         else:
             print("Список пуст")
 
+    def move_tracker(self, elem, word, obj, direct = True):
+        alf = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+        while True:
+            if elem == obj.value:
+                obj.linkSL.singly_add_element(word)
+                self.last = obj
+                break
+            else:
+                if elem not in list(alf):
+                    print("Возможно в тексте есть иностранный алфавит")
+                    break
+                else:
+                    if direct:
+                        obj = obj.link2
+                        self.counter += 1
+                    else:
+                        obj = obj.link1
+                        self.counter -= 1
+
     def search_element(self, elem, word):
-        c = 0
         alf = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
         direct_distance = abs(alf.find(elem) - self.counter)
         reverse_distance = len(alf) - direct_distance
@@ -52,34 +70,10 @@ class Doubly_Linked():
             obj = self.last
             if (self.counter > alf.find(elem) and direct_distance < reverse_distance) or (
                     self.counter < alf.find(elem) and direct_distance > reverse_distance):
-                while True:
-                    if elem == obj.value:
-                        obj.linkSL.singly_add_element(word)
-                        self.last = obj
-                        break
-                    else:
-                        if c >= len(alf):
-                            print("Возможно в тексте есть иностранный алфавит")
-                            break
-                        else:
-                            obj = obj.link2
-                            self.counter += 1
-                            c += 1
+                self.move_tracker(elem, word, obj, direct=True)
             elif (self.counter > alf.find(elem) and direct_distance > reverse_distance) or (
                     self.counter < alf.find(elem) and direct_distance < reverse_distance):
-                while True:
-                    if elem == obj.value:
-                        obj.linkSL.singly_add_element(word)
-                        self.last = obj
-                        break
-                    else:
-                        if c >= len(alf):
-                            print("Возможно в тексте есть иностранный алфавит")
-                            break
-                        else:
-                            obj = obj.link1
-                            self.counter -= 1
-                            c += 1
+                self.move_tracker(elem, word, obj, direct=False)
             elif alf.find(elem) == self.counter:
                 obj.linkSL.singly_add_element(word)
                 self.last = obj

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from doubly_linked import *
 
 DL = Doubly_Linked()
-with open("text.txt", "r", encoding="utf-8") as f:
+with open("text/text.txt", "r", encoding="utf-8") as f:
     text = "".join(e.lower() for e in f.readline() if e.isalnum() or e == " ").split()
 
 alf = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"


### PR DESCRIPTION
в коде поиска элемента в двусвязном кольцевом списке происходит дублирование кода, соответственно, его можно вынести в отдельный метод, тем самым избавившись от явного дублирования кода и повысив его читаемость